### PR TITLE
fix: clash.tpl: 代理名称去重，为 proxy 名称添加引号

### DIFF
--- a/clash.tpl
+++ b/clash.tpl
@@ -14,18 +14,22 @@
 {{- end -}}
 
 {{- $supportedProxies := list -}}
+{{- $seenNames := dict -}}
 {{- range $proxy := .Proxies -}}
   {{- if or (eq $proxy.Type "shadowsocks") (eq $proxy.Type "vmess") (eq $proxy.Type "vless") (eq $proxy.Type "trojan") (eq $proxy.Type "hysteria2") (eq $proxy.Type "tuic") (eq $proxy.Type "anytls") -}}
-    {{- $supportedProxies = append $supportedProxies $proxy -}}
+    {{- if not (hasKey $seenNames $proxy.Name) -}}
+      {{- $supportedProxies = append $supportedProxies $proxy -}}
+      {{- $seenNames = set $seenNames $proxy.Name true -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
 {{- $proxyNames := "" -}}
 {{- range $proxy := $supportedProxies -}}
   {{- if eq $proxyNames "" -}}
-    {{- $proxyNames = $proxy.Name -}}
+    {{- $proxyNames = printf "%q" $proxy.Name -}}
   {{- else -}}
-    {{- $proxyNames = printf "%s, %s" $proxyNames $proxy.Name -}}
+    {{- $proxyNames = printf "%s, %q" $proxyNames $proxy.Name -}}
   {{- end -}}
 {{- end -}}
 
@@ -52,7 +56,7 @@ dns:
   ipv6: true
   enhanced-mode: fake-ip
   fake-ip-range: 198.18.0.1/16
-  fake-ip-filter: ['*.lan', lens.l.google.com, '*.srv.nintendo.net', '*.stun.playstation.net', 'xbox.*.*.microsoft.com', '*.xboxlive.com', '*.msftncsi.com', '*.msftconnecttest.com']
+  fake-ip-filter: ['*.lan', 'lens.l.google.com', '*.srv.nintendo.net', '*.stun.playstation.net', 'xbox.*.*.microsoft.com', '*.xboxlive.com', '*.msftncsi.com', '*.msftconnecttest.com']
   default-nameserver: [119.29.29.29, 223.5.5.5]
   nameserver: [system, 119.29.29.29, 223.5.5.5]
   fallback: [8.8.8.8, 1.1.1.1]


### PR DESCRIPTION
1. 添加按 `name` 去重的逻辑：
  - 创建了 `$seenNames` 字典来跟踪已见过的 `proxy `名称
  - 在遍历 `proxy` 时，只有当 `name` 未见过时才添加到 `$supportedProxies` 中
  - 每次添加新 `proxy` 时，将其 `name` 标记为已见过
2. 修复了 `$proxyNames` 变量的构建逻辑：
  - 现在使用 %q 格式化来自动为包含特殊字符（如`[]`）的 `proxy` 名称添加引号
