### PR TITLE
修复 sing-box 模板中裸 vmess 会添加 tls 选项的 bug

### DIFF
--- a/sing-box-1.12.gotmpl
+++ b/sing-box-1.12.gotmpl
@@ -172,7 +172,11 @@
 { "type": "vless", "tag": "{{ $name }}", "server": "{{ $server }}", "server_port": {{ $port }}, "uuid": "{{ $pwd }}"{{ $flowOpts }}{{ if $transportOpts }}, {{ $transportOpts }}{{ end }}{{ if $realityOpts }}, {{ $realityOpts }}{{ else if $tlsOpts }}, {{ $tlsOpts }}{{ end }} }
 
 {{- else if eq $proxy.Type "vmess" -}}
-{ "type": "vmess", "tag": "{{ $name }}", "server": "{{ $server }}", "server_port": {{ $port }}, "uuid": "{{ $pwd }}", "security": "auto"{{ if $transportOpts }}, {{ $transportOpts }}{{ end }}{{ if $tlsOpts }}, {{ $tlsOpts }}{{ end }} }
+{{- $vmessTLS := "" -}}
+{{- if and $tlsOpts (ne $proxy.Transport "tcp") -}}
+  {{- $vmessTLS = $tlsOpts -}}
+{{- end -}}
+{ "type": "vmess", "tag": "{{ $name }}", "server": "{{ $server }}", "server_port": {{ $port }}, "uuid": "{{ $pwd }}", "security": "auto"{{ if $transportOpts }}, {{ $transportOpts }}{{ end }}{{ if $vmessTLS }}, {{ $vmessTLS }}{{ end }} }
 
 {{- else if or (eq $proxy.Type "hysteria2") (eq $proxy.Type "hy2") -}}
 {{- $obfsOpts := "" -}}


### PR DESCRIPTION
修复 sing-box 模板中裸 vmess（服务器设置中的安全设置为 `NONE`）会添加 tls 选项的 bug
已在 ppanel-server 1.2.8 和 sing-box 1.13.0 中测试