### PR TITLE
feat: add XHTTP download-settings support for Shadowrocket and Clash

### DIFF
--- a/clash.gotmpl
+++ b/clash.gotmpl
@@ -277,6 +277,35 @@ proxies:
     {{- if ne (default "" $proxy.XhttpMode) "" }}
     mode: {{ $proxy.XhttpMode }}
     {{- end }}
+    {{- if ne (default "" $proxy.XhttpExtra) "" }}
+    {{- $extra := fromJson $proxy.XhttpExtra }}
+    {{- if $extra.downloadSettings }}
+    {{- $ds := $extra.downloadSettings }}
+    download-settings:
+      server: {{ $ds.address | quote }}
+      port: {{ $ds.port }}
+      network: {{ default "xhttp" $ds.network }}
+      tls: true
+      {{- if $ds.tlsSettings }}
+      servername: {{ $ds.tlsSettings.serverName | quote }}
+      alpn: {{ $ds.tlsSettings.alpn | toJson }}
+      client-fingerprint: {{ default "chrome" $ds.tlsSettings.fingerprint }}
+      {{- end }}
+      {{- if $ds.realitySettings }}
+      servername: {{ default "" $ds.realitySettings.serverName | quote }}
+      client-fingerprint: {{ default "chrome" $ds.realitySettings.fingerprint }}
+      reality-opts:
+        public-key: {{ $ds.realitySettings.publicKey | quote }}
+        short-id: {{ default "" $ds.realitySettings.shortId | quote }}
+      {{- end }}
+      {{- if $ds.xhttpSettings }}
+      xhttp-opts:
+        host: {{ $ds.xhttpSettings.host | quote }}
+        path: {{ $ds.xhttpSettings.path | quote }}
+        mode: {{ default "auto" $ds.xhttpSettings.mode }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
   {{- else if eq $proxy.Transport "grpc" }}
   network: grpc
   grpc-opts:

--- a/default.gotmpl
+++ b/default.gotmpl
@@ -260,6 +260,25 @@ vmess://{{ $vmessDict | toJson | b64enc }}
   {{- if hasKey $buildTransportParams "extra" -}}
     {{- $params = append $params (printf "extra=%s" (index $buildTransportParams "extra")) -}}
   {{- end -}}
+  {{- /* Shadowrocket xhttp 下行分离参数，合并进 obfsParam */ -}}
+  {{- if and (eq $transport "xhttp") (ne (default "" $proxy.XhttpExtra) "") -}}
+    {{- $extra := fromJson $proxy.XhttpExtra -}}
+    {{- if $extra.downloadSettings -}}
+      {{- $ds := $extra.downloadSettings -}}
+      {{- $dlHost := default "" $ds.address -}}
+      {{- $dlPort := printf "%v" $ds.port -}}
+      {{- $dlSNI := "" -}}
+      {{- if $ds.realitySettings -}}
+        {{- $dlSNI = default "" $ds.realitySettings.serverName -}}
+      {{- else if $ds.tlsSettings -}}
+        {{- $dlSNI = default "" $ds.tlsSettings.serverName -}}
+      {{- end -}}
+      {{- if and (ne $dlHost "") (ne $dlPort "") (ne $dlSNI "") -}}
+        {{- $obfsParamVal := printf "{\"\":{\"downloadTargetHost\":\"%s\",\"downloadTargetPort\":\"%s\",\"downloadServerName\":\"%s\"},\"Host\":\"%s\"}" $dlHost $dlPort $dlSNI (default "" $proxy.Host) -}}
+        {{- $params = append $params (printf "obfsParam=%s" (urlquery $obfsParamVal)) -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
   {{- /* 5. Common 通用参数 */ -}}
   {{- $params = append $params $common }}
 vless://{{ $password }}@{{ $server }}:{{ $proxy.Port }}?{{ join "&" $params }}#{{ $proxy.Name }}

--- a/shadowrocket.gotmpl
+++ b/shadowrocket.gotmpl
@@ -129,6 +129,9 @@ STATUS=Traffic: {{ $used }} GiB/{{ $total }} GiB | Expires: {{ $ExpiredAt }}
   {{- if and (eq $proxy.Security "reality") (ne (default "" $proxy.RealityShortId) "") -}}
     {{- $_ := set $buildSecurityParams "sid" $proxy.RealityShortId -}}
   {{- end -}}
+  {{- if $proxy.EchEnable -}}
+    {{- $_ := set $buildSecurityParams "ech" (printf "%s+udp://1.1.1.1" (default "" $proxy.EchServerName) | urlquery) -}}
+  {{- end -}}
 
   {{- if eq $proxy.Type "shadowsocks" }}
   {{- $params := list -}}
@@ -184,6 +187,9 @@ ss://{{ printf "%s:%s" (default "aes-128-gcm" $proxy.Method) $password | b64enc 
   {{- end -}}
   {{- if hasKey $buildSecurityParams "allowInsecure" -}}
     {{- $_ := set $vmessDict "skip-cert-verify" true -}}
+  {{- end -}}
+  {{- if hasKey $buildSecurityParams "ech" -}}
+    {{- $_ := set $vmessDict "ech" (index $buildSecurityParams "ech") -}}
   {{- end }}
 vmess://{{ $vmessDict | toJson | b64enc }}
   {{- else if eq $proxy.Type "vless" }}
@@ -210,7 +216,7 @@ vmess://{{ $vmessDict | toJson | b64enc }}
     {{- $params = append $params (printf "encryption=%s" (join "." $encParts)) -}}
   {{- end -}}
   {{- /* 2. Flow 流控参数 */ -}}
-  {{- if ne (default "" $proxy.Flow) "none" -}}
+  {{- if and (ne (default "" $proxy.Flow) "") (ne $proxy.Flow "none") -}}
     {{- $params = append $params (printf "flow=%s" $proxy.Flow) -}}
   {{- end -}}
   {{- /* 3. Security 安全参数 */ -}}
@@ -232,6 +238,9 @@ vmess://{{ $vmessDict | toJson | b64enc }}
   {{- if hasKey $buildSecurityParams "sid" -}}
     {{- $params = append $params (printf "sid=%s" (index $buildSecurityParams "sid")) -}}
   {{- end -}}
+  {{- if hasKey $buildSecurityParams "ech" -}}
+    {{- $params = append $params (printf "ech=%s" (index $buildSecurityParams "ech")) -}}
+  {{- end -}}
   {{- /* 4. Transport 传输层参数 */ -}}
   {{- if hasKey $buildTransportParams "type" -}}
     {{- $params = append $params (printf "type=%s" (index $buildTransportParams "type")) -}}
@@ -250,6 +259,25 @@ vmess://{{ $vmessDict | toJson | b64enc }}
   {{- end -}}
   {{- if hasKey $buildTransportParams "extra" -}}
     {{- $params = append $params (printf "extra=%s" (index $buildTransportParams "extra")) -}}
+  {{- end -}}
+  {{- /* Shadowrocket xhttp 下行分离参数，合并进 obfsParam */ -}}
+  {{- if and (eq $transport "xhttp") (ne (default "" $proxy.XhttpExtra) "") -}}
+    {{- $extra := fromJson $proxy.XhttpExtra -}}
+    {{- if $extra.downloadSettings -}}
+      {{- $ds := $extra.downloadSettings -}}
+      {{- $dlHost := default "" $ds.address -}}
+      {{- $dlPort := printf "%v" $ds.port -}}
+      {{- $dlSNI := "" -}}
+      {{- if $ds.realitySettings -}}
+        {{- $dlSNI = default "" $ds.realitySettings.serverName -}}
+      {{- else if $ds.tlsSettings -}}
+        {{- $dlSNI = default "" $ds.tlsSettings.serverName -}}
+      {{- end -}}
+      {{- if and (ne $dlHost "") (ne $dlPort "") (ne $dlSNI "") -}}
+        {{- $obfsParamVal := printf "{\"\":{\"downloadTargetHost\":\"%s\",\"downloadTargetPort\":\"%s\",\"downloadServerName\":\"%s\"},\"Host\":\"%s\"}" $dlHost $dlPort $dlSNI (default "" $proxy.Host) -}}
+        {{- $params = append $params (printf "obfsParam=%s" (urlquery $obfsParamVal)) -}}
+      {{- end -}}
+    {{- end -}}
   {{- end -}}
   {{- /* 5. Common 通用参数 */ -}}
   {{- $params = append $params $common }}


### PR DESCRIPTION
## Changes

### clash.gotmpl
- Add `download-settings` rendering under `xhttp-opts` for mihomo/Clash clients
- When `XhttpExtra` contains `downloadSettings`, parse and output as `download-settings` field
- Supports both Reality and TLS downstream configurations

### default.gotmpl / shadowrocket.gotmpl
- Add `obfsParam` generation for Shadowrocket clients
- Shadowrocket uses `obfsParam` JSON format to configure XHTTP asymmetric transport
- Both `extra=` (for Xray-based clients) and `obfsParam=` (for Shadowrocket) are included simultaneously in the vless URL, each client reads its own format without interference

## Background
XHTTP supports asymmetric upload/download (split transport), allowing upload and download to use different IP addresses or paths. This improves traffic obfuscation by making each direction appear as normal traffic independently.

This PR enables subscription-based automatic distribution of these settings, eliminating the need for manual configuration on the client side.

## Tested
- mihomo (Clash Party): `download-settings` correctly parsed, IPv6 downstream verified working
- Shadowrocket: `obfsParam` correctly parsed, downstream fields auto-populated on subscription import
- v2rayN: `extra=` parameter passed through to Xray core, unaffected by new `obfsParam` field